### PR TITLE
Add public chat section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ This website is built with the classics, intentionally avoiding modern framework
 
 ---
 
+## 🏃‍♂️ Running the Local Server
+
+Some sections (guestbook, public chat and downloads) require the Node.js backend.
+
+```bash
+npm --prefix backend install
+npm --prefix backend start
+```
+
+Then open [http://localhost:3000](http://localhost:3000) in your browser.
+
+---
+
 3.  **Open `index.html`:** Simply open the `index.html` file in your web browser.
 
 ---

--- a/backend/data/chat.json
+++ b/backend/data/chat.json
@@ -1,0 +1,11 @@
+{
+  "messages": [
+    {
+      "id": 1,
+      "name": "Pam",
+      "message": "Ciao a tutti! :smiley:",
+      "date": "14/04/2025",
+      "time": "16:00"
+    }
+  ]
+}

--- a/public/chat.js
+++ b/public/chat.js
@@ -1,0 +1,173 @@
+function initChat() {
+  const API_BASE    = '/api';
+  const EMOTE_PATH  = '/images/emotes/';
+
+  const chatForm    = document.getElementById('chat-form');
+  const chatMessages= document.getElementById('chat-messages');
+  const msgInput    = document.getElementById('chat-message');
+  const emoteWrapper= document.getElementById('chat-emote-wrapper');
+
+  let EMOTES = [];
+  let emoteCategories = {};
+
+  buildToolbar();
+  loadEmotes().then(loadMessages);
+  mountSubmit();
+
+  async function loadMessages() {
+    try {
+      const res = await fetch(`${API_BASE}/chat`);
+      if (!res.ok) throw new Error();
+      const msgs = await res.json();
+      renderMessages(msgs);
+    } catch (err) {
+      chatMessages.innerHTML = '<div class="error">Errore caricamento messaggi</div>';
+    }
+  }
+
+  function renderMessages(list) {
+    chatMessages.innerHTML = list.map(m => {
+      const txt = renderMessage(m.message);
+      return `<div class="chat-entry"><span class="chat-name">${sanitize(m.name)}</span> <span class="chat-text">${txt}</span> <span class="chat-time">${m.time}</span></div>`;
+    }).join('');
+    chatMessages.scrollTop = chatMessages.scrollHeight;
+  }
+
+  function mountSubmit() {
+    chatForm.addEventListener('submit', async e => {
+      e.preventDefault();
+      const fd = new FormData(chatForm);
+      const payload = { name: fd.get('name'), message: fd.get('message') };
+      try {
+        const res = await fetch(`${API_BASE}/chat`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        if (!res.ok) throw new Error();
+        chatForm.reset();
+        loadMessages();
+      } catch (err) {
+        alert('Errore nell\'invio del messaggio');
+      }
+    });
+  }
+
+  function buildToolbar() {
+    const formatBox = document.createElement('div');
+    formatBox.className = 'format-buttons';
+    formatBox.innerHTML = `
+<button class="toolbar-btn" data-tag="b">B</button>
+<button class="toolbar-btn" data-tag="i">I</button>
+<button class="toolbar-btn" data-tag="quote">"</button>`;
+    const group = document.createElement('div');
+    group.className = 'toolbar-group format-group';
+    group.appendChild(formatBox);
+    emoteWrapper.appendChild(group);
+
+    formatBox.querySelectorAll('.toolbar-btn').forEach(btn => {
+      btn.addEventListener('click', () => wrapSelection(
+        msgInput,
+        `[${btn.dataset.tag}]`,
+        `[/${btn.dataset.tag}]`
+      ));
+    });
+  }
+
+  function buildEmotePicker(data) {
+    const tabsContainer = document.createElement('div');
+    tabsContainer.className = 'emote-tabs';
+    const contentContainer = document.createElement('div');
+    contentContainer.id = 'chat-emote-picker';
+    contentContainer.className = 'emote-content';
+    emoteWrapper.appendChild(tabsContainer);
+    emoteWrapper.appendChild(contentContainer);
+
+    const categories = Object.keys(data);
+    if (categories.length === 0) {
+      contentContainer.innerHTML = '<div class="emote-empty">Nessun emoticon</div>';
+      return;
+    }
+
+    categories.forEach((cat, idx) => {
+      const btn = document.createElement('button');
+      btn.className = 'emote-tab-btn' + (idx===0 ? ' active' : '');
+      btn.dataset.category = cat;
+      btn.textContent = cat === 'root' ? 'General' : cat.charAt(0).toUpperCase()+cat.slice(1);
+      btn.addEventListener('click', e => {
+        document.querySelectorAll('#chat-emote-wrapper .emote-tab-btn').forEach(b => b.classList.remove('active'));
+        e.target.classList.add('active');
+        showCat(cat);
+      });
+      tabsContainer.appendChild(btn);
+    });
+
+    showCat(categories[0]);
+
+    function showCat(category) {
+      contentContainer.innerHTML = '';
+      if (!data[category]) return;
+      const grid = document.createElement('div');
+      grid.className = 'emote-grid';
+      grid.innerHTML = data[category].map(e => `<img src="${EMOTE_PATH}${e.file}" alt="${e.code}" title="${e.code}" class="emote-btn">`).join('');
+      contentContainer.appendChild(grid);
+      grid.querySelectorAll('.emote-btn').forEach(img => img.addEventListener('click', () => insertAtCursor(msgInput, img.alt)));
+    }
+  }
+
+  async function loadEmotes() {
+    try {
+      const res = await fetch(`${API_BASE}/emotes`);
+      if (!res.ok) throw new Error();
+      const data = await res.json();
+      emoteCategories = data;
+      EMOTES = [];
+      Object.keys(data).forEach(k => { if (Array.isArray(data[k])) EMOTES = EMOTES.concat(data[k]); });
+      buildEmotePicker(data);
+    } catch(err) {
+      console.error('emotes', err);
+    }
+  }
+
+  function wrapSelection(textarea, before, after) {
+    const { selectionStart:s, selectionEnd:e, value:v } = textarea;
+    textarea.value = v.slice(0, s) + before + v.slice(s, e) + after + v.slice(e);
+    textarea.focus();
+    textarea.selectionStart = s + before.length;
+    textarea.selectionEnd   = e + before.length;
+  }
+  function insertAtCursor(textarea, text) {
+    const start = textarea.selectionStart;
+    const end   = textarea.selectionEnd;
+    textarea.value = textarea.value.slice(0, start) + text + textarea.value.slice(end);
+    textarea.focus();
+    textarea.selectionStart = textarea.selectionEnd = start + text.length;
+  }
+
+  function parseFormatting(str) {
+    return str
+      .replace(/\[b\](.*?)\[\/b\]/gis, '<strong>$1</strong>')
+      .replace(/\[i\](.*?)\[\/i\]/gis, '<em>$1</em>')
+      .replace(/\[quote\](.*?)\[\/quote\]/gis, '<blockquote>$1</blockquote>');
+  }
+  function sanitize(str) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+  function replaceEmotes(str) {
+    let out = str;
+    EMOTES.forEach(({ code, file }) => {
+      const regex = new RegExp(code.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'), 'g');
+      out = out.replace(regex, `<img src="${EMOTE_PATH}${file}" alt="${code}" class="emote-in-msg">`);
+    });
+    return out;
+  }
+  function renderMessage(raw) {
+    return replaceEmotes(parseFormatting(sanitize(raw))).replace(/\n/g, '<br>');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (document.getElementById('chat-form')) initChat();
+});

--- a/public/index.html
+++ b/public/index.html
@@ -7,11 +7,13 @@
     <title>✨ Pamsite! ✨</title>
     <link rel="stylesheet" href="/styles/style.css">
     <link rel="stylesheet" href="/styles/guestbook.css">
+    <link rel="stylesheet" href="/styles/chat.css">
     <link rel="stylesheet" href="/styles/audioplayer.css">
     <script src="https://w.soundcloud.com/player/api.js"></script>
 
     <script src="/script.js"    defer></script>
     <script src="/guestbook.js" defer></script>
+    <script src="/chat.js"     defer></script>
 </head>
  
 

--- a/public/pages/home-page.html
+++ b/public/pages/home-page.html
@@ -18,4 +18,15 @@
       <img src="images/gifs/Smileonthebeach.gif" alt="Welcome GIF">
     </div>
   </section>
+
+  <section id="chat-section" class="chat-section">
+    <div class="chat-title">💬 Chat Pubblica</div>
+    <div id="chat-messages" class="chat-messages"></div>
+    <form id="chat-form" class="chat-form">
+      <input type="text" name="name" placeholder="Il tuo nome" required>
+      <div id="chat-emote-wrapper"></div>
+      <textarea id="chat-message" name="message" rows="3" placeholder="Scrivi un messaggio" required></textarea>
+      <button type="submit">Invia</button>
+    </form>
+  </section>
   

--- a/public/script.js
+++ b/public/script.js
@@ -125,6 +125,9 @@ function closeModal() {
             renderSection('cursors')
           ]);
           break;
+        case 'home-page':
+          initChat?.();
+          break;
         case 'guestbook-page':
           initGuestbook?.();
           break;

--- a/public/styles/chat.css
+++ b/public/styles/chat.css
@@ -1,0 +1,65 @@
+/* Simple public chat styles */
+.chat-section {
+  background: var(--c-bg-dark) url('https://i.gifer.com/3IsS.gif') repeat;
+  padding: 1rem;
+  border: var(--border-thick) ridge var(--c-yellow);
+  border-radius: var(--radius-lg);
+  animation: glow 2s infinite alternate;
+  margin-top: 1rem;
+}
+.chat-title {
+  text-align: center;
+  color: var(--c-yellow);
+  font-weight: bold;
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+.chat-messages {
+  max-height: 300px;
+  overflow-y: auto;
+  background-color: rgba(0, 0, 40, 0.8);
+  border: var(--border-normal) groove var(--c-magenta);
+  border-radius: var(--radius-md);
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.chat-entry {
+  margin-bottom: 0.5rem;
+}
+.chat-name {
+  color: var(--c-cyan);
+  font-weight: bold;
+  margin-right: 0.25rem;
+}
+.chat-time {
+  color: var(--c-text-muted);
+  font-size: 0.75rem;
+  margin-left: 0.5rem;
+}
+.chat-form input,
+.chat-form textarea {
+  width: 100%;
+  margin-bottom: 0.5rem;
+  background-color: var(--c-bg-deeper);
+  border: var(--border-normal) ridge var(--c-cyan);
+  color: #fff;
+  padding: 0.5rem;
+  border-radius: var(--radius-sm);
+  font-family: var(--ff-fun);
+}
+.chat-form button {
+  background: linear-gradient(to bottom, #ff00ff, #cc00cc);
+  color: #ffffff;
+  border: 3px outset #00ffff;
+  padding: 10px;
+  font-weight: bold;
+  cursor: pointer;
+  border-radius: 12px;
+}
+#chat-emote-wrapper { margin-bottom: 0.5rem; }
+.emote-grid { display:flex; flex-wrap:wrap; gap:4px; padding:4px; }
+.emote-btn { cursor:pointer; margin:2px; }
+.emote-tabs { display:flex; gap:4px; margin-bottom:4px; }
+.emote-tab-btn { padding:2px 6px; border:1px solid var(--c-magenta); background:var(--c-bg-light); color:#fff; cursor:pointer; }
+.emote-tab-btn.active { background:var(--c-magenta); }
+.emote-in-msg { vertical-align: middle; }


### PR DESCRIPTION
## Summary
- add backend storage for chat messages
- expose new /api/chat endpoints
- add public chat component on home page
- include chat CSS and JS
- initialize chat client in router
- document backend install steps

## Testing
- `node --check backend/server.js`
- `node --check public/chat.js`
- `npm --prefix backend start`

------
https://chatgpt.com/codex/tasks/task_e_68483d414ddc832bad869a4c52e3108c